### PR TITLE
Add ÖYD Code of Conduct

### DIFF
--- a/code-of-conduct-samples/turkish-oyd-coc.md
+++ b/code-of-conduct-samples/turkish-oyd-coc.md
@@ -1,0 +1,46 @@
+# Özgür Yazılım Derneği Raconu (CoC)
+
+_(**racon** İta. ragione: kaide, usul, akıl selim, mantık, uyulması gereken kurallar bütünü)_
+
+Bu yönerge Özgür Yazılım Derneği'nin; çevrimiçi de dahil olmak üzere kurduğu, paydaşı olduğu etkinlikler ve topluluklar kapsamında herkese güvenli ve huzurlu bir etkileşim alanı sunmak için oluşturulmuştur. ÖYD'nin etki alanının sürdüğü süre boyunca bu yönerge geçerlidir. Bu yönergeyi benimsemek adına yapılan atıflarda, atıfı yapan taraf yönergenin uygulayanı sayılır.
+
+**Yürütücüler**, ilgili alanlarda dernek tarafından yetkilendirilmiş kişileri, etkinlik komitelerini, çevrimiçi iletişim alanlarında ilgili kanaldan sorumlu kişileri, diğer tüm istisnai hallerde dernek yönetim kurulunu ifade eder.
+
+**Rahatsızlık**; yaş, cinsiyet, cinsiyet kimliği, cinsel yönelim, engellilik hali, ırk, dil, insanların vücut biçimleri ve farkları sebebiyle ötekileştiren ayrımcı/yaralayıcı ifadeler, hedef gösterme, bireylere yönelik şiddet içeren söylemler, etkinliğin veya iletişimin sürdürülmesine engel olma ve her nevi taciz durumlarını ifade eder.
+
+**Taraflar**, derneğin varlık gösterdiği tüm alanlarda etkin olan kişi veya kurumları ifade eder. 
+
+**İstenmeyen kişi** (Persona non grata), dernek alanlarından süreli veya süresiz olarak uzaklaştırılan kişileri ifade eder.
+
+Taraflardan, koşullar önem arz etmeksizin herkese karşı nazik, yardımsever ve hoşgörülü olmaları, hiç kimseye rahatsızlık vermemeleri beklenmektedir. Etrafına rahatsızlık veren taraflar; diğer taraflar ve/veya yürütücüler tarafından öncelikle uyarılacak, ardından istenmeyen kişi ilan edilecektir. Yürütücülerin ortak kararıyla rahatsızlık verenler hakkında süresiz uzaklaştırma gibi yaptırımlar da uygulanabilir.
+
+Etkinliklerde sponsorlar veya ev sahipleri de taraf olarak kabul edilmektedir, dolayısıyla rahatsızlık karşıtı önlemlere tabidirler. Sponsorlar ve ev sahipleri için de yaptırımlar aynı derecede uygulanacaktır.
+
+
+Topluluğun alanlarında; faşizme, cinsiyetçiliğe, türcülüğe, ırkçılığa, şovenizme, LGBTİ+ fobiye, zenofobiye ve bunlarla sınırlı olmamakla birlikte her nevi özgürlük düşmanı, ayrımcı ve nefret içerikli düşünce, söylem  ve davranışa kesinlikle izin verilmeyecektir. Bu tür söylem ve davranışlarda bulunduğu tespit edilen taraflar, istenmeyen kişi ilan edilir ve tüm alanlardan uzaklaştırılır.
+
+Rahatsızlığa maruz kalınması, bir başkasına rahatsızlık verildiğine şahit olunması veya endişe duyulması halinde en kısa zamanda bir yürütücüye ulaşılmalıdır. Yürütücüleri; iletişim kanallarındaki ifadelerden, etkinliklerde ise varsa yaka kartlarından, yoksa belirleyici işaretlerden tanıyabilirsiniz.
+
+Yaşanan herhangi bir ihlal durumunda, ihlalin giderilmesi için gerekenlerin yapılması yürütücülerin yetkisi dahilindedir. İhlalin giderilmesi, olaya müdahil olan kişilerin şikayetine veya affına bağlı değildir. 
+
+Etkinliklerde tarafların kişisel mahremiyetine saygı göstermek için, önceden izin almaksızın hiçbir tarafın fotoğrafı veya videosu çekilmemelidir. Etkinliğe göre, bazı taraflarda fotoğrafının ve videosunun hiçbir koşulda çekilmemesi ve paylaşılmaması gerektiğini gösteren işaretler bulunabilir. Tüm taraflardan bu tarz işaretlere uymaları beklenmektedir. İzinsiz bir şekilde çekilmiş bir fotoğraf veya videoda kişinin belirlenebilir olması durumunda, görüntünün anlaşılmayacak şekilde bozulması, o kişinin mahremiyetini koruyacaktır.
+
+Bunların haricinde üçüncü kişilerin kişisel bilgilerini veya kimliğini ifşa etmek kesinlikle süresiz olarak istenmeyen kişi ilan edilme sebebidir.
+
+
+### Tavsiyeler
+
+**Paylaşımcı olun.** İletişim alanlarında, karşınızdaki tarafın teknik seviyesinin sizinkinden farklı olabileceğini aklınızda bulundurup, mümkün olabildiğince çözüm odaklı ve yapıcı olun.
+
+**Nazik olun.** Herkesin sosyal becerilerinin farklı olabileceğini göz önünde bulundurarak beklemediğiniz veya alışık olmadığınız bir davranış karşısında anlayışlı olun.
+
+**Davetkar olun.** Topluluğa yeni katılan kişilerle iletişimde hassasiyet gösterin. Hiç kimse yeni katıldığı bir ortamda görünmezmiş gibi hissetmek istemez. İnsanlara onları gördüğünüzü hissettirin ve ortama dahil olmaları için davetkar olun.
+
+**Dışadönük olun.** Uzun zamandır görmediğiniz arkadaşlarınızı özlediğinizi biliyoruz ancak etkinlikler ve topluluklar yeni kişilerle tanışmak için biçilmiş kaftandır. Aranıza yeni kişileri almaktan çekinmeyin.
+
+**Düşünceli olun.** Etkinliğin planlanan bir akışı olduğunu düşünerek, sorduğunuz soruları belirtilen süreler dahilinde makul bir vakit alacak şekilde sorun. Eğer soramadığınız bir sorunuz olursa, e-posta ve benzeri kanallardan iletebilirsiniz. Etkinlik konuşmacıları ve yürütücüleri, sorularınızı memnuniyetle cevaplayacaklardır.
+
+
+Eğer herhangi bir sebepten istenmeyen kişi ilan edildiyseniz ve bu durumdan memnun değilseniz, özeleştirinizi verebilirsiniz. Verdiğiniz özeleştiri, dernekçe değerlendirilecek ve nihai karar size ulaştırılacaktır. İstenmeyen kişilerle ilgili soru, öneri ve temyiz mercii Özgür Yazılım Derneği Yönetim Kurulu, bu metnin başka topluluklarca benimsenmesi durumunda ise ilgili topluluğun yürütücüleridir. 
+
+Bu yönergede belirtilmeyen her nevi durumda, konsensüs kararları, protokol ve tüzük hükümleri; ya da ilgili toplulukların yönergeleri geçerlidir.


### PR DESCRIPTION
Hello there,

[Özgür Yazılım Derneği](https://oyd.org.tr) has been applying a form of code of conduct for a while and since the CoC allows third parties to adopt it only by referencing; I suppose it should be included in examples. The CoC also features a proposal for lacking Turkish translation for the term "Code of Conduct" by repurposing an old semantic-drifted word "racon".

Sincerely,